### PR TITLE
Bump dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle
 cabal-dev
 *.o
 *.hi

--- a/language-lua.cabal
+++ b/language-lua.cabal
@@ -44,7 +44,7 @@ Library
 
   Other-modules:     Text.PrettyPrint.Leijen
 
-  Build-depends:     base >= 4.5 && < 4.9,
+  Build-depends:     base >= 4.5 && < 4.11,
                      deepseq,
                      array >= 0.4 && < 0.6,
                      mtl >= 2.0 && < 2.3,
@@ -59,7 +59,7 @@ Test-Suite tests
   Type:              exitcode-stdio-1.0
   Hs-source-dirs:    tests
   Main-is:           Main.hs
-  Build-depends:     base >= 4.5 && < 4.9,
+  Build-depends:     base >= 4.5 && < 4.11,
                      deepseq,
                      directory,
                      filepath,

--- a/src/Text/Parsec/LTok.hs
+++ b/src/Text/Parsec/LTok.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, MonoLocalBinds #-}
 
 -- | Lexer/Parsec interface
 module Text.Parsec.LTok


### PR DESCRIPTION
Add MonoLocalBinds to avoid warning.

Perhaps we should just simplify the types though...